### PR TITLE
Remove confirmation prompt for Reset button

### DIFF
--- a/out/extension.js
+++ b/out/extension.js
@@ -90,7 +90,7 @@ function activate(context) {
         terminal.sendText(clip, false);
         terminal.sendText('', true);
     }));
-    // Execute `git reset --hard` after explicit confirmation from the user
+    // Execute `git reset --hard` immediately with no confirmation
     const runHardReset = vscode.commands.registerCommand(resetHardCmd, () => __awaiter(this, void 0, void 0, function* () {
         const folders = vscode.workspace.workspaceFolders;
         if (!folders || folders.length === 0) {
@@ -98,9 +98,6 @@ function activate(context) {
             return;
         }
         const cwd = folders[0].uri.fsPath;
-        const choice = yield vscode.window.showWarningMessage('This will run `git reset --hard` and discard ALL local changes. Are you sure?', 'Yes, reset hard', 'Cancel');
-        if (choice !== 'Yes, reset hard')
-            return;
         const terminal = createTerminal(cwd, 'Git Reset (Git Bash)');
         if (!terminal)
             return;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -87,7 +87,7 @@ export function activate(context: vscode.ExtensionContext) {
     terminal.sendText('', true);
   });
 
-  // Execute `git reset --hard` after explicit confirmation from the user
+  // Execute `git reset --hard` immediately with no confirmation
   const runHardReset = vscode.commands.registerCommand(resetHardCmd, async () => {
     const folders = vscode.workspace.workspaceFolders;
     if (!folders || folders.length === 0) {
@@ -95,13 +95,6 @@ export function activate(context: vscode.ExtensionContext) {
       return;
     }
     const cwd = folders[0].uri.fsPath;
-
-    const choice = await vscode.window.showWarningMessage(
-      'This will run `git reset --hard` and discard ALL local changes. Are you sure?',
-      'Yes, reset hard',
-      'Cancel'
-    );
-    if (choice !== 'Yes, reset hard') return;
 
     const terminal = createTerminal(cwd, 'Git Reset (Git Bash)');
     if (!terminal) return;


### PR DESCRIPTION
## Summary
- run `git reset --hard` directly when clicking Reset status bar button

## Testing
- `npm test` *(fails: Cannot find module 'vscode' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68a9001aa3408330b35aa9f17c731e87